### PR TITLE
Refactoring of RuneFinder.select/2

### DIFF
--- a/elixir/rf.exs
+++ b/elixir/rf.exs
@@ -7,16 +7,11 @@ defmodule RuneFinder do
   end
 
   defp select(line_stream, query_words) do
-    Enum.reduce(line_stream, 0, fn line, count ->
+    Enum.count(line_stream, fn line ->
       [code, name | _] = String.split(line, ";")
 
-      if MapSet.subset?(query_words, tokenize(name)) do
-        display(code, name)
-        count + 1
-      else
-        count
-      end
-    end)
+      MapSet.subset?(query_words, tokenize(name)) and display(code, name) 
+    end) 
   end
 
   defp summary(count), do: IO.puts("(#{count} found)")


### PR DESCRIPTION
Firstly, congratulations on your talk on ElixirBrasil 2019! :smile_cat:

Given your invitation to review and comment on your code, I thought I would pitch in.

Overall, I'd say it looks great! A tiny simplification I'd make is in the use of `Enum.reduce`. It is tremendously flexible as you know but not always the easiest function to read or skim through. Fortunately, some of the main use cases for it were already implemented in the `Enum` library, and `count/2` sugars the implementation really well here. It returns the number of elements which evaluated to `true` given the function in the second parameter.

Now, for the side effect of calling `display` on valid elements there are several approaches, I chose to leverage short-circuiting in order to keep it a one liner check. It works as long as `display` returns a truthy value.

Hope you keep thriving on Elixir! 